### PR TITLE
Improvement: greatly reduce release profile binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,13 @@ predicates = "3.1.3"
 assert_fs = "1.1.3"
 # Creating temporary directories
 tempfile = "3.20.0"
+
+[profile.release]
+opt-level = "z"
+debug = true
+lto = true
+codegen-units = 1
+panic = "abort"
+incremental = true
+split-debuginfo = "packed"
+strip = "symbols"


### PR DESCRIPTION
# Description
adds release profile flags in Cargo.toml to greatly reduce the binary size, result is ~53% decrease in size

only note is that `panic = "abort"` will have rust abort instead of unwinding which means that there wont be some useful backtraces when a panic occurs, up to you if you want to keep that or remove it

also build times are faster (~20-30s from my testing) and thats after cargo clean, with things cached it will be a much larger decrease because of `incremental = true`



# How this been tested
<!-- mark all applicable items with x inside brackets -->
- [ ] Run tests
- [ ] Tested in real cases

# Checklist
<!-- you should do all of this, mark applicable items with x inside brackets -->
- [x] Your changes don't generate new warnings or errors
- [ ] ~You have run `cargo clippy` and `cargo fmt`~ created unrelated changes so i wont do this
- [x] You have tested this
- [ ] You have updated documentation

# Screenshots
| before | after |
|--------|--------|
| ![](https://github.com/user-attachments/assets/33717b6f-4b76-4903-8d49-9db961a9ed0e) | ![](https://github.com/user-attachments/assets/4f07571e-da8d-43db-b7b5-b634b50ec6bb) | 


