### PR TITLE
Feat: export command

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -42,6 +42,8 @@ pub enum Commands {
     Print(PrintArgs),
     /// Initialize config file.
     InitConfig,
+    /// Export variable to .env file
+    Export(ExportArgs),
 }
 
 /// Args for print command
@@ -159,6 +161,21 @@ pub struct DeleteArgs {
         num_args = 1..
     )]
     pub process: Vec<String>,
+}
+
+/// Args for export command
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct ExportArgs {
+    /// File anme to be exported as
+    #[arg(required = true)]
+    pub file_name: String,
+    /// Environment variable(s) name
+    #[arg(
+        required = true,
+        last = true,
+        num_args = 1..
+    )]
+    pub keys: Vec<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes https://github.com/ankddev/envfetch/issues/54
# Description

adds export command which exports selected variables to a .env file

# How this been tested

- [x] Run tests
- [x] Tested in real cases

# Checklist

- [x] Your changes don't generate new warnings or errors
- [x] You have run `cargo clippy` and `cargo fmt`, only kept changed that affected my changes, make a commit yourself that fixes everything else
- [x] You have tested this
- [ ] You have updated documentation

# Screenshots

![alacritty_ba1LebAa95](https://github.com/user-attachments/assets/34ca4c8b-6baa-4237-bdf6-0595a4f53636)
